### PR TITLE
[wip] migrate repository to proof-of-concept status

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -1,11 +1,13 @@
-digital.lafayette.edu ui [![Build Status](https://travis-ci.org/LafayetteCollegeLibraries)](https://travis-ci.org/LafayetteCollegeLibraries/digital.lafayette.edu)
+digital.lafayette.edu ui [![Build Status](https://travis-ci.org/LafayetteCollegeLibraries/digital.lafayette.edu.svg?branch=master)](https://travis-ci.org/LafayetteCollegeLibraries/digital.lafayette.edu) [![Coverage Status](https://coveralls.io/repos/github/LafayetteCollegeLibraries/digital.lafayette.edu/badge.svg?branch=master)](https://coveralls.io/github/LafayetteCollegeLibraries/digital.lafayette.edu?branch=master)
 ========================
 
 Proof-of-concept [React][1] / [Redux][2] front-end for [Blacklight][3]. This
 takes the path begun by [metadb-ui][4], but strips out the metadata-editing
 components to act solely as a view-layer (with some search-related state
-management). **This project is currently on hold** as we move towards a more
-traditional approach using [Hyrax][5]/[Hyku][6] - Blacklight - [Spotlight][7].
+management).
+
+**This project is currently on hold** as we move towards a more traditional
+approach using [Hyrax][5]/[Hyku][6] - Blacklight - [Spotlight][7].
 
 See [LafayetteCollegeLibraries/lafayette-preserve][8] for the [Sufia][9]-based
 backend.

--- a/readme.markdown
+++ b/readme.markdown
@@ -1,18 +1,31 @@
-digital.lafayette.edu ui [![Build Status](https://travis-ci.com/LafayetteCollegeLibraries/digital.lafayette.edu.svg?token=RMxCrEacXTux6rxyXvxo)](https://travis-ci.com/LafayetteCollegeLibraries/digital.lafayette.edu)
+digital.lafayette.edu ui [![Build Status](https://travis-ci.org/LafayetteCollegeLibraries)](https://travis-ci.org/LafayetteCollegeLibraries/digital.lafayette.edu)
 ========================
 
-[React](https://facebook.github.io/react) / [Redux](http://redux.js.org)
-front-end for Blacklight.
+Proof-of-concept [React][1] / [Redux][2] front-end for [Blacklight][3]. This
+takes the path begun by [metadb-ui][4], but strips out the metadata-editing
+components to act solely as a view-layer (with some search-related state
+management). **This project is currently on hold** as we move towards a more
+traditional approach using [Hyrax][5]/[Hyku][6] - Blacklight - [Spotlight][7].
 
-getting started
----------------
+See [LafayetteCollegeLibraries/lafayette-preserve][8] for the [Sufia][9]-based
+backend.
+
+set-up
+------
 
 ```
 git clone https://github.com/LafayetteCollegeLibraries/digital.lafayette.edu
 cd digital.lafayette.edu
 npm install
-npm run dev
+API_BASE_URL="http://instance/of/lafayette-preserve" npm run dev
 ```
 
-**Note**: the AJAX requests require the environment variable `API_BASE_URL` to
-be defined when starting.
+[1]: https://facebook.github.io/react
+[2]: http://redux.js.org
+[3]: http://projectblacklight.org
+[4]: https://github.com/LafayetteCollegeLibraries/metadb-ui
+[5]: http://hyr.ax/
+[6]: http://hydrainabox.projecthydra.org/
+[7]: http://spotlight.projectblacklight.org/
+[8]: https://github.com/LafayetteCollegeLibraries/lafayette-preserve
+[9]: http://sufia.io

--- a/src/components/WorkHeader/test.js
+++ b/src/components/WorkHeader/test.js
@@ -17,7 +17,7 @@ describe('<WorkHeader />', function () {
   })
 
   it('calls the `fetchingMessage` prop when `isFetching` is true', function () {
-    const fetchingMessage = () => `hey I'm fetchin' here!`
+    const fetchingMessage = () => 'hey I\'m fetchin\' here!'
     const isFetching = true
 
     const $el = shallowEl({fetchingMessage, isFetching})

--- a/src/store/search/endpoints.js
+++ b/src/store/search/endpoints.js
@@ -3,7 +3,7 @@ import history from '../../history'
 import { flattenValues } from './utils'
 import { session } from '../../utils'
 
-export const SEARCH_PATH = '/catalog.json'
+export const SEARCH_PATH = process.env.SEARCH_PATH || '/catalog.json'
 export const PER_PAGE_LIMIT = 50
 
 export function search ({query, facets, range, meta}) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,10 @@ module.exports = {
         JSON.stringify(process.env.API_BASE_URL)
       ),
 
+      'process.env.SEARCH_PATH': (
+        JSON.stringify(process.env.SEARCH_PATH)
+      ),
+
       'process.env.NODE_ENV': (
         JSON.stringify(process.env.NODE_ENV || 'development')
       ),


### PR DESCRIPTION
As the result of some staffing changes, we're planning on moving the repository to more of a stock Hyku solution. We need to do a few things before we close this up for good:

- [x] update readme.markdown to reflect the current status.
- [x] make repository public
- [x] move to use to travis-ci.org for CI
- [ ] ~add page (wiki?) detailing how to get a working example using http://demo.projectblacklight.org~ (this will take a few more changes than could probably be outlined in a brief wiki; maybe a future branch?)